### PR TITLE
changed charts route to return album objects

### DIFF
--- a/server/routes/chartYear.js
+++ b/server/routes/chartYear.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import Chart from '../models/Charts.js';
+import Albums from '../models/Albums.js';
+import mongoose from 'mongoose'
 
 const router = express.Router();
 
@@ -16,8 +18,15 @@ router.get("/", async (req,res)=> {
 router.get("/:year", async (req,res)=> {
     try {
         const data =  await Chart.find({year: req.params.year}).sort({rank: "ascending"});
+        let newdata = data.map(async element => {
+            let id = new mongoose.Types.ObjectId(element.album)
+            let obj = await Albums.find({_id: id})
+            return obj[0];
+        })
+        let results = await Promise.all(newdata);
+        console.log(results);
         res.setHeader('Access-Control-Allow-Origin', 'http://localhost:3000');
-        res.status(200).json(data);
+        res.status(200).json(results);
     } catch (error) {
         res.status(404).json({message: error.message});
     }


### PR DESCRIPTION
changed chart routes to return array of album objects instead of albumID, avoids extra API calls in client

album objects order is preserved, index 0 = rank 1, index 1 = rank 2, etc.